### PR TITLE
Use ‘multiply’ blend mode for images on light background

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -268,7 +268,7 @@ header h1 {
 }
 
 img {
-  mix-blend-mode: darken;
+  mix-blend-mode: multiply;
 }
 
 [data-theme="dark"] img {

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -273,7 +273,7 @@ img {
 
 [data-theme="dark"] img {
   filter: invert(1) hue-rotate(180deg);
-  mix-blend-mode: lighten;
+  mix-blend-mode: screen;
 }
 
 @media only print {


### PR DESCRIPTION
To my eye `multiply` feels closer to the look of ink on paper than `darken`. With `darken` the grey areas are too desaturated relative to the background they sit on.

Before (darken) | After (multiply)
---|---
![image](https://user-images.githubusercontent.com/355079/111910737-8354e200-8a5a-11eb-932c-64a3431f2e9a.png) | ![image](https://user-images.githubusercontent.com/355079/111910747-8d76e080-8a5a-11eb-940d-3d63d51e818d.png)
