### PR TITLE
Fix letter o being used instead of 0

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -56,7 +56,7 @@ layout: base.njk
     </ul>
 
     <p class="mb12">
-        Price £1 1s. od. net
+        Price £1 1s. 0d. net
     </p>
 
     <p class="italic mb2">


### PR DESCRIPTION
I believe _od_ should be _0d_, where d is short for pence in pre-decimal currency.

So the original price of the book would have been one pound, one shilling and zero pence.

https://en.wikipedia.org/wiki/%C2%A3sd